### PR TITLE
stm32: adc: Fix adc_power_off_async for already disabled adc

### DIFF
--- a/lib/stm32/common/adc_common_v2.c
+++ b/lib/stm32/common/adc_common_v2.c
@@ -116,7 +116,8 @@ void adc_power_off_async(uint32_t adc)
 		ADC_CR(adc) |= stops;
 		while (ADC_CR(adc) & checks);
 	}
-	ADC_CR(adc) |= ADC_CR_ADDIS;
+	if (ADC_CR(adc) & ADC_CR_ADEN)
+		ADC_CR(adc) |= ADC_CR_ADDIS;
 }
 
 /**


### PR DESCRIPTION
The ADDIS bit is only allowed to be set by software if the ADC is
already enabled (ADEN=1).
